### PR TITLE
feat(generator): add spec-generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mocha": "^3.0.2"
   },
   "dependencies": {
-    "jsdoc-to-assert": "~2.4.0"
+    "doctrine": "^1.3.0",
+    "jsdoc-to-assert": "^2.5.2"
   }
 }

--- a/src/generators.js
+++ b/src/generators.js
@@ -1,5 +1,6 @@
 // LICENSE : MIT
 "use strict";
+const doctrine = require("doctrine");
 import {trimSpaceEachLine} from "./util";
 export class SimpleGenerator {
   assert(expression) {
@@ -10,12 +11,31 @@ export class SimpleGenerator {
 export class NodeAssertGenerator {
   assert(expression) {
     const trimmedExpression = trimSpaceEachLine(expression.split("\n")).join("");
-    return `assert(${trimmedExpression}, 'Invalid JSDoc param: ${trimmedExpression}');`;
+    return `assert(${trimmedExpression}, 'Invalid JSDoc: ${trimmedExpression}');`;
+  }
+}
+export class SpecGenerator {
+  constructor(tag) {
+    this.nameOfValue = tag.name;
+    this.typeString = doctrine.type.stringify(tag.type, {compact: true});
+    this.jsdocLikeString = `@${tag.title} {${this.typeString}} ${tag.name}`;
+  }
+
+  assert(expression) {
+    const trimmedExpression = trimSpaceEachLine(expression.split("\n")).join("");
+    const title = `TypeError: babel-plugin-jsdoc-to-assert`;
+    const expectedMessage = `Expected type: ${this.jsdocLikeString}`;
+    const actualMessage = `Actual value:`;
+    const actualValue = this.nameOfValue;
+    return `if(!(${trimmedExpression})){
+      console.warn('${title}\\n${expectedMessage}\\n${actualMessage}', ${actualValue});
+      console.assert(${trimmedExpression}, 'Invalid JSDoc: ${trimmedExpression}');
+}`;
   }
 }
 export class ThrowGenerator {
   assert(expression) {
     const trimmedExpression = trimSpaceEachLine(expression.split("\n")).join("");
-    return `if(${trimmedExpression}){ throw new TypeError('Invalid JSDoc @param: ${trimmedExpression}'); }`;
+    return `if(!(${trimmedExpression})){ throw new TypeError('Invalid JSDoc: ${trimmedExpression}'); }`;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 import {CommentConverter} from "jsdoc-to-assert"
 import {AssignmentExpressionLeftToString} from "./ast-util";
 import {trimSpaceEachLine} from "./util";
-import {NodeAssertGenerator, SimpleGenerator, ThrowGenerator} from "./generators";
+import {NodeAssertGenerator, SimpleGenerator, ThrowGenerator, SpecGenerator} from "./generators";
 /**
  * `comment` node contain @type, return true
  * @param {Object} comment
@@ -44,6 +44,11 @@ function useGenerator(options = {}) {
     }
   }
   // assert
+  if (options.useSpecReporter) {
+    return {
+      Generator: SpecGenerator
+    }
+  }
   if (options.useNodeAssert) {
     return {
       Generator: NodeAssertGenerator
@@ -149,7 +154,7 @@ export default function({types: t, template}) {
           return;
         }
         const leadingComments = path.parentPath.node.leadingComments;
-        if(leadingComments == null) {
+        if (leadingComments == null) {
           return;
         }
         injectParameterAssert(path, leadingComments, this.opts);

--- a/test/fixtures/AssertOption/expected.js
+++ b/test/fixtures/AssertOption/expected.js
@@ -4,6 +4,6 @@
  * @param {string[]} [c] - this is a param.
  */
 const myFunc = (param, b, c) => {
-  assert(typeof param === "number", 'Invalid JSDoc param: typeof param === "number"');
-  assert(typeof b === "string", 'Invalid JSDoc param: typeof b === "string"');
+  assert(typeof param === "number", 'Invalid JSDoc: typeof param === "number"');
+  assert(typeof b === "string", 'Invalid JSDoc: typeof b === "string"');
 };

--- a/test/fixtures/ObjectMethodB/expected.js
+++ b/test/fixtures/ObjectMethodB/expected.js
@@ -14,6 +14,8 @@ const cli = {
    */
   executeWithOptions(cliOptions, files, text, stdinFilename) {
     console.assert(typeof cliOptions === "object");
-    console.assert(Array.isArray(files));
+    console.assert(Array.isArray(files) && files.every(function (item) {
+      return typeof item === "string";
+    }));
   }
 };

--- a/test/fixtures/SpecGenerator-param/.babelrc
+++ b/test/fixtures/SpecGenerator-param/.babelrc
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    [
+      "../../../src/",
+      {
+        "useSpecReporter": true,
+        "checkAtParam": true
+      }
+    ]
+  ]
+}

--- a/test/fixtures/SpecGenerator-param/actual.js
+++ b/test/fixtures/SpecGenerator-param/actual.js
@@ -1,0 +1,6 @@
+/**
+ * @param {number} x - this is a param.
+ * @param {string[]} y - this is a param.
+ */
+function myFunc(x, y) {
+}

--- a/test/fixtures/SpecGenerator-param/expected.js
+++ b/test/fixtures/SpecGenerator-param/expected.js
@@ -1,0 +1,19 @@
+/**
+ * @param {number} x - this is a param.
+ * @param {string[]} y - this is a param.
+ */
+function myFunc(x, y) {
+  if (!(typeof x === "number")) {
+    console.warn('TypeError: babel-plugin-jsdoc-to-assert\nExpected type: @param {number} x\nActual value:', x);
+    console.assert(typeof x === "number", 'Invalid JSDoc: typeof x === "number"');
+  }
+
+  if (!(Array.isArray(y) && y.every(function (item) {
+    return typeof item === "string";
+  }))) {
+    console.warn('TypeError: babel-plugin-jsdoc-to-assert\nExpected type: @param {Array.<string>} y\nActual value:', y);
+    console.assert(Array.isArray(y) && y.every(function (item) {
+      return typeof item === "string";
+    }), 'Invalid JSDoc: Array.isArray(y) && y.every(function(item){ return (typeof item === "string"); })');
+  }
+}

--- a/test/fixtures/SpecGenerator-type/.babelrc
+++ b/test/fixtures/SpecGenerator-type/.babelrc
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    [
+      "../../../src/",
+      {
+        "useSpecReporter": true,
+        "checkAtParam": true,
+        "checkAtType": true
+      }
+    ]
+  ]
+}

--- a/test/fixtures/SpecGenerator-type/actual.js
+++ b/test/fixtures/SpecGenerator-type/actual.js
@@ -1,0 +1,8 @@
+/**
+ * @type {string}
+ */
+const value = "s";
+/**
+ * @type {string[]}
+ */
+const array = ["s"];

--- a/test/fixtures/SpecGenerator-type/expected.js
+++ b/test/fixtures/SpecGenerator-type/expected.js
@@ -1,0 +1,23 @@
+/**
+ * @type {string}
+ */
+const value = "s";
+/**
+ * @type {string[]}
+ */
+
+if (!(typeof value === "string")) {
+  console.warn('TypeError: babel-plugin-jsdoc-to-assert\nExpected type: @type {string} value\nActual value:', value);
+  console.assert(typeof value === "string", 'Invalid JSDoc: typeof value === "string"');
+}
+
+const array = ["s"];
+
+if (!(Array.isArray(array) && array.every(function (item) {
+  return typeof item === "string";
+}))) {
+  console.warn('TypeError: babel-plugin-jsdoc-to-assert\nExpected type: @type {Array.<string>} array\nActual value:', array);
+  console.assert(Array.isArray(array) && array.every(function (item) {
+    return typeof item === "string";
+  }), 'Invalid JSDoc: Array.isArray(array) && array.every(function(item){ return (typeof item === "string"); })');
+}


### PR DESCRIPTION
Option

```js
      {
        "useSpecReporter": true,
      }
```

## Example

JSDoc

```js
/**
 * @type {string[]}
 */
const array = ["s", 1];
```

Output:

```sh
TypeError: babel-plugin-jsdoc-to-assert
Expected type: @type {Array.<string>} array
Actual value: [ 's', 1 ]
```

## Related

close #4 