### PR TITLE
fix: avoid to convert duplicated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,9 @@ function containTypeComment(comment) {
  * @returns {boolean}
  */
 function maybeSkip(path) {
+  if(path.__jsdoc_to_assert_checked__) {
+    return true;
+  }
   const {node} = path;
   if (node.leadingComments != null && node.leadingComments.length > 0) {
     return false;
@@ -96,6 +99,11 @@ export default function({types: t, template}) {
     if (asserts.length === 0) {
       return;
     }
+    // add check mark and it is not enumerable
+    Object.defineProperty(path, "__jsdoc_to_assert_checked__", {
+      enumerable: false,
+      value: true
+    });
     const functionDeclarationString = trimSpaceEachLine(asserts).join("\n");
     const builtAssert = template(functionDeclarationString)();
     const bodyPath = path.get("body");

--- a/test/fixtures/ObjectMethod_with_es2015/.babelrc
+++ b/test/fixtures/ObjectMethod_with_es2015/.babelrc
@@ -1,0 +1,13 @@
+{
+  "presets": [
+    "es2015"
+  ],
+  "plugins": [
+    [
+      "../../../src/",
+      {
+        "simple": true
+      }
+    ]
+  ]
+}

--- a/test/fixtures/ObjectMethod_with_es2015/actual.js
+++ b/test/fixtures/ObjectMethod_with_es2015/actual.js
@@ -1,0 +1,8 @@
+var object = {
+  /**
+   * @param {number} x - this is a param.
+   * @param {string} y - this is a param.
+   */
+  method(x, y) {
+  }
+};

--- a/test/fixtures/ObjectMethod_with_es2015/expected.js
+++ b/test/fixtures/ObjectMethod_with_es2015/expected.js
@@ -1,0 +1,12 @@
+"use strict";
+
+var object = {
+  /**
+   * @param {number} x - this is a param.
+   * @param {string} y - this is a param.
+   */
+  method: function method(x, y) {
+    console.assert(typeof x === "number");
+    console.assert(typeof y === "string");
+  }
+};


### PR DESCRIPTION
Currently, some case bad transforms.
It is because use with other transform plugin like `babel-preset-es2015`.

```js
        /**
         * @param {?Object} data
         */
        doRender1: function(data) {
            return data;
        },
        /**
         * @param {?Object} data
         */
        doRender2(data) {
            return data;
        },
```

to

```js
        /**
         * @param {?Object} data
         */
        doRender1: function doRender1(data) {
            if (!(data == null || (typeof data === 'undefined' ? 'undefined' : (0, _typeof3['default'])(data)) === "object")) {
                console.assert(data == null || (typeof data === 'undefined' ? 'undefined' : (0, _typeof3['default'])(data)) === "object", 'Expected type: @param {?Object} data\nActual value:', data, '\nFailure assertion: (data == null || typeof data === "object")');
            }

            return data;
        },
        /**
         * @param {?Object} data
         */
        doRender2: function doRender2(data) {
            if (!(data == null || (typeof data === 'undefined' ? 'undefined' : (0, _typeof3['default'])(data)) === "object")) {
                console.assert(data == null || (typeof data === 'undefined' ? 'undefined' : (0, _typeof3['default'])(data)) === "object", 'Expected type: @param {?Object} data\nActual value:', data, '\nFailure assertion: (data == null || typeof data === "object")');
            }

            if (!(data == null || (typeof data === 'undefined' ? 'undefined' : (0, _typeof3['default'])(data)) === "object")) {
                console.assert(data == null || (typeof data === 'undefined' ? 'undefined' : (0, _typeof3['default'])(data)) === "object", 'Expected type: @param {?Object} data\nActual value:', data, '\nFailure assertion: (data == null || typeof data === "object")');
            }

            return data;
        },
```

This PR fix this issue by adding `__jsdoc_to_assert_checked__` check mark.

close https://github.com/azu/jsdoc-to-assert/issues/12